### PR TITLE
Fix missing null on linked array field

### DIFF
--- a/src/generated-type-helpers.ts
+++ b/src/generated-type-helpers.ts
@@ -5,7 +5,9 @@ export type LinkedFieldType<
     TypeName extends string & keyof ParentType,
     Type,
     Plural extends boolean,
-> = Plural extends true ? Type[] : null extends ParentType[TypeName] ? Type | null : Type;
+> = Plural extends true ?
+    null[] extends ParentType[TypeName] ? (Type | null)[] : Type[] :
+    null extends ParentType[TypeName] ? Type | null : Type;
 
 export type OperationFieldType<
     ParentTypeName extends string,


### PR DESCRIPTION
E.g, `Nameplate.badges` is `(Badge | null)[]`, while linked array fields`player.nameplate.badges` is `Badge[]`, which is incorrect.